### PR TITLE
Added support for explicit input format

### DIFF
--- a/Manager.php
+++ b/Manager.php
@@ -275,8 +275,8 @@ class Manager
     private function checkImage($path)
     {
         // remove explicit format if present
-        if(strpos($path, ':') !== false) {
-            $path = explode(':', $path);
+        if(preg_match("/:(?!\/\/)/", $path) === 1) {
+            $path = preg_split("/:(?!\/\/)/", $path);
             $path = $path[1];
         }
 

--- a/Manager.php
+++ b/Manager.php
@@ -274,8 +274,11 @@ class Manager
      */
     private function checkImage($path)
     {
+        if(strpos($path, ':') !== false) {
+            $path = explode(':', $path)[1];
+        }
         if (!file_exists($this->getWebDirectory() . '/' . $path) && !file_exists($path)) {
-            throw new NotFoundException(sprintf("Unable to find the image \"%s\" to cache", $path));
+            throw new NotFoundException(sprintf("Unable to find image \"%s\"", $path));
         }
 
         if (!is_file($this->getWebDirectory() . '/' . $path) && !is_file($path)) {

--- a/Manager.php
+++ b/Manager.php
@@ -274,9 +274,12 @@ class Manager
      */
     private function checkImage($path)
     {
+        // remove explicit format if present
         if(strpos($path, ':') !== false) {
-            $path = explode(':', $path)[1];
+            $path = explode(':', $path);
+            $path = $path[1];
         }
+
         if (!file_exists($this->getWebDirectory() . '/' . $path) && !file_exists($path)) {
             throw new NotFoundException(sprintf("Unable to find image \"%s\"", $path));
         }


### PR DESCRIPTION
When working with temp files without file extensions or with .cr2 files, imagemagick might [require an explicit input format](http://www.imagemagick.org/script/formats.php): ``cr2:/temp/tempfile``.
