### PR TITLE
Bump priority

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -20,7 +20,7 @@ services:
         class: Snowcap\ImBundle\Listener\MogrifySubscriber
         arguments: [%kernel.root_dir%, @snowcap_im.manager]
         tags:
-            - { name: doctrine.event_subscriber}
+            - { name: doctrine.event_subscriber, priority: 1 }
 
     snowcap_im.form_extension:
         class: Snowcap\ImBundle\Form\Extension\ImageTypeExtension


### PR DESCRIPTION
When using SnowcapImBundle's annotations while also using other file handling bundles, it is necessary for SnowcapImBundle's event subscriber to be executed first, so that other file actions will be executed on the mogrified file.

Example: VichUploaderBundle uploads files to a local or remote filesystem when an entity is persisted. Currently, VichUploadBundle uploads the file and only afterwards, SnowcapImBundle mogrifies the local temp file.