### PR TITLE
Cache metadata

### DIFF
--- a/DependencyInjection/SnowcapImExtension.php
+++ b/DependencyInjection/SnowcapImExtension.php
@@ -41,5 +41,15 @@ class SnowcapImExtension extends Extension
         $container->setParameter('snowcap_im.cache_path', $config['cache_path']);
         $container->setParameter('snowcap_im.timeout', $config['timeout']);
         $container->setParameter('snowcap_im.binary_path', $config['binary_path']);
+
+        $metadataCache = '%kernel.cache_dir%/snowcap_im';
+        $metadataCache = $container->getParameterBag()->resolveValue($metadataCache);
+        if (!is_dir($metadataCache)) {
+            mkdir($metadataCache, 0777, true);
+        }
+        $container
+            ->getDefinition('snowcap_im.metadata.cache')
+            ->replaceArgument(0, $metadataCache)
+        ;
     }
 }

--- a/Doctrine/Driver/MogrifyDriver.php
+++ b/Doctrine/Driver/MogrifyDriver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Snowcap\ImBundle\Doctrine\Driver;
+
+use Metadata\Driver\DriverInterface;
+use Metadata\MergeableClassMetadata;
+use Doctrine\Common\Annotations\Reader;
+use Snowcap\ImBundle\Doctrine\Metadata\MogrifyMetadata;
+
+class MogrifyDriver implements DriverInterface
+{
+    const MOGRIFY = 'Snowcap\ImBundle\Doctrine\Mapping\Mogrify';
+
+    private $reader;
+
+    public function __construct(Reader $reader)
+    {
+        $this->reader = $reader;
+    }
+
+    public function loadMetadataForClass(\ReflectionClass $class)
+    {
+        $classMetadata = new MergeableClassMetadata($class->getName());
+
+        foreach ($class->getProperties() as $property) {
+            $field = $this->reader->getPropertyAnnotation($property, self::MOGRIFY);
+
+            if(!is_null($field)) {
+                $propertyMetadata = new MogrifyMetadata($class->getName(), $property->getName());
+                $propertyMetadata->params = $field->params;
+
+                $classMetadata->addPropertyMetadata($propertyMetadata);
+            }
+        }
+
+        return $classMetadata;
+    }
+}

--- a/Doctrine/Mapping/Mogrify.php
+++ b/Doctrine/Mapping/Mogrify.php
@@ -17,10 +17,16 @@ use Doctrine\Common\Annotations\Annotation;
  * Annotation definition class
  *
  * @Annotation
+ * @Annotation\Target("PROPERTY")
  * @codeCoverageIgnore
  */
 class Mogrify extends Annotation
 {
-    /** @var array */
+    /**
+     * Identfier of a pre-configured format or key-value pairs of IM parameters
+     *
+     * @Required
+     * @var string|array<string>
+     */
     public $params;
 }

--- a/Doctrine/Metadata/MogrifyMetadata.php
+++ b/Doctrine/Metadata/MogrifyMetadata.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Snowcap\ImBundle\Doctrine\Metadata;
+
+use Metadata\PropertyMetadata as BasePropertyMetadata;
+
+class MogrifyMetadata extends BasePropertyMetadata
+{
+    /** @var string|array<string> */
+    public $params;
+}

--- a/Doctrine/Metadata/MogrifyMetadata.php
+++ b/Doctrine/Metadata/MogrifyMetadata.php
@@ -6,6 +6,25 @@ use Metadata\PropertyMetadata as BasePropertyMetadata;
 
 class MogrifyMetadata extends BasePropertyMetadata
 {
-    /** @var string|array<string> */
+    /**
+     * @var string|array<string>
+     */
     public $params;
+
+    public function serialize()
+    {
+        return serialize(array(
+            $this->class,
+            $this->name,
+            $this->params,
+        ));
+    }
+
+    public function unserialize($str)
+    {
+        list($this->class, $this->name, $this->params) = unserialize($str);
+
+        $this->reflection = new \ReflectionProperty($this->class, $this->name);
+        $this->reflection->setAccessible(true);
+    }
 }

--- a/Listener/MogrifySubscriber.php
+++ b/Listener/MogrifySubscriber.php
@@ -24,13 +24,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 class MogrifySubscriber implements EventSubscriber
 {
-    private $config = array();
-
-    /**
-     * @var string
-     */
-    private $rootDir;
-
     /**
      * @var \Metadata\MetadataFactoryInterface
      */
@@ -47,13 +40,11 @@ class MogrifySubscriber implements EventSubscriber
     private $propertyAccessor;
 
     /**
-     * @param string                    $rootDir            The dir to generate files
      * @param MetadataFactoryInterface  $metadataFactory
      * @param ImManager                 $imManager          The ImBundle manager instance
      */
-    public function __construct($rootDir, MetadataFactoryInterface $metadataFactory, ImManager $imManager)
+    public function __construct(MetadataFactoryInterface $metadataFactory, ImManager $imManager)
     {
-        $this->rootDir = $rootDir;
         $this->metadataFactory = $metadataFactory;
         $this->imManager = $imManager;
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -16,11 +16,21 @@ services:
         tags:
             -  { name: twig.extension }
 
+    snowcap_im.metadata.mogrify_driver:
+        class: Snowcap\ImBundle\Doctrine\Driver\MogrifyDriver
+        public: false
+        arguments: [@annotation_reader]
+
+    snowcap_im.metadata.mogrify_factory:
+        class: Metadata\MetadataFactory
+        public: false
+        arguments: [@snowcap_im.metadata.mogrify_driver]
+
     snowcap_im.mogrify_subscriber:
         class: Snowcap\ImBundle\Listener\MogrifySubscriber
-        arguments: [%kernel.root_dir%, @snowcap_im.manager]
+        arguments: [%kernel.root_dir%, @snowcap_im.metadata.mogrify_factory, @snowcap_im.manager]
         tags:
-            - { name: doctrine.event_subscriber}
+            - { name: doctrine.event_subscriber, priority: 1 }
 
     snowcap_im.form_extension:
         class: Snowcap\ImBundle\Form\Extension\ImageTypeExtension

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,14 +21,22 @@ services:
         public: false
         arguments: [@annotation_reader]
 
+    snowcap_im.metadata.cache:
+        class: Metadata\Cache\FileCache
+        public: false
+        arguments:
+            - {}
+
     snowcap_im.metadata.mogrify_factory:
         class: Metadata\MetadataFactory
         public: false
         arguments: [@snowcap_im.metadata.mogrify_driver]
+        calls:
+            - [setCache, ["@snowcap_im.metadata.cache"]]
 
     snowcap_im.mogrify_subscriber:
         class: Snowcap\ImBundle\Listener\MogrifySubscriber
-        arguments: [%kernel.root_dir%, @snowcap_im.metadata.mogrify_factory, @snowcap_im.manager]
+        arguments: [@snowcap_im.metadata.mogrify_factory, @snowcap_im.manager]
         tags:
             - { name: doctrine.event_subscriber, priority: 1 }
 


### PR DESCRIPTION
This PR doesn't add any functionality, but
- separates metadata into a value object
- separates reading of metadata into a doctrine annotation driver
- suggests the use of Symfony's property access class
- Introduces a file cache for the metadata to avoid repeated reflection work

This will improve performance, allow to cover more code by tests and facilitate extending this bundle.