### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,11 +4,11 @@ parameters:
 
 services:
     snowcap_im.wrapper:
-        class: %snowcap_im.wrapper_class%
-        arguments: ['\Symfony\Component\Process\Process', %snowcap_im.binary_path%, %snowcap_im.timeout%]
+        class: '%snowcap_im.wrapper_class%'
+        arguments: ['\Symfony\Component\Process\Process', '%snowcap_im.binary_path%', '%snowcap_im.timeout%']
     snowcap_im.manager:
-        class: %snowcap_im.manager_class%
-        arguments: ['@snowcap_im.wrapper', %kernel.root_dir%, %snowcap_im.web_path%, %snowcap_im.cache_path%, %snowcap_im.formats%]
+        class: '%snowcap_im.manager_class%'
+        arguments: ['@snowcap_im.wrapper', '%kernel.root_dir%', '%snowcap_im.web_path%', '%snowcap_im.cache_path%', '%snowcap_im.formats%']
 
     snowcap_im.twig:
         class: Snowcap\ImBundle\Twig\Extension\ImExtension


### PR DESCRIPTION
Not quoting the scalar "%snowcap_im.wrapper_class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 7.

Not quoting the scalar "%snowcap_im.binary_path%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 8.

Not quoting the scalar "%snowcap_im.timeout%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 8.

Not quoting the scalar "%snowcap_im.manager_class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 10.

Not quoting the scalar "%kernel.root_dir%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 11.

Not quoting the scalar "%snowcap_im.web_path%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 11.

Not quoting the scalar "%snowcap_im.cache_path%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 11.

Not quoting the scalar "%snowcap_im.formats%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/DependencyInjection/../Resources/config/services.yml" on line 11.