### PR TITLE
Not quoting the scalar

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 snowcap_im_default_index:
-    path: %snowcap_im.cache_path%/{format}/{path}
+    path: '%snowcap_im.cache_path%/{format}/{path}'
     requirements:
         path: (.+)
     defaults: { _controller: SnowcapImBundle:Default:index }


### PR DESCRIPTION
User Deprecated: Not quoting the scalar "%snowcap_im.cache_path%/{format}/{path}" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/snowcap/im-bundle/Snowcap/ImBundle/Resources/config/routing.yml" on line 2.